### PR TITLE
Sync email changes to processor

### DIFF
--- a/lib/pay/billable.rb
+++ b/lib/pay/billable.rb
@@ -12,6 +12,8 @@ module Pay
       has_many :charges, foreign_key: :owner_id
       has_many :subscriptions, foreign_key: :owner_id
 
+      after_save :update_processor_email
+
       attribute :plan, :string
       attribute :quantity, :integer
       attribute :card_token, :string
@@ -82,6 +84,12 @@ module Pay
     end
 
     private
+
+    def update_processor_email
+      if saved_change_to_email? && subscriptions.any?
+        send("update_#{processor}_email!")
+      end
+    end
 
     def check_for_processor
       raise StandardError, "No payment processor selected. Make sure to set the User's `processor` attribute to either 'stripe' or 'braintree'." unless processor

--- a/lib/pay/billable/braintree.rb
+++ b/lib/pay/billable/braintree.rb
@@ -64,6 +64,12 @@ module Pay
         update_subscriptions_to_payment_method(result.payment_method.token)
       end
 
+      def update_braintree_email!
+        braintree_customer.update(
+          "email" => email
+        )
+      end
+
       def braintree_trial_end_date(subscription)
         return unless subscription.trial_period
         Time.zone.parse(subscription.first_billing_date)

--- a/lib/pay/billable/stripe.rb
+++ b/lib/pay/billable/stripe.rb
@@ -35,6 +35,12 @@ module Pay
         result
       end
 
+      def update_stripe_email!
+        customer = stripe_customer
+        customer.email = email
+        customer.save
+      end
+
       def stripe_subscription(subscription_id)
         ::Stripe::Subscription.retrieve(subscription_id)
       end

--- a/test/pay/billable/braintree_test.rb
+++ b/test/pay/billable/braintree_test.rb
@@ -67,4 +67,11 @@ class Pay::Billable::Braintree::Test < ActiveSupport::TestCase
       assert @billable.subscribed?
     end
   end
+
+  test 'email changed' do
+    @billable.subscriptions.expects(:any?).returns(true)
+    @billable.email = "mynewemail@example.org"
+    @billable.expects(:update_braintree_email!)
+    @billable.save
+  end
 end

--- a/test/pay/billable/stripe_test.rb
+++ b/test/pay/billable/stripe_test.rb
@@ -157,4 +157,11 @@ class Pay::Billable::Stripe::Test < ActiveSupport::TestCase
     assert_equal @billable.processor, 'stripe'
     assert_not_nil @billable.processor_id
   end
+
+  test 'email changed' do
+    @billable.subscriptions.expects(:any?).returns(true)
+    @billable.email = "mynewemail@example.org"
+    @billable.expects(:update_stripe_email!)
+    @billable.save
+  end
 end


### PR DESCRIPTION
This should sync the local email changes to the payment processor if the user who's email got updated has any subscriptions.

@excid3 not sure if we want to do this in a background job instead?