### PR TITLE
Fix some small mailer bugs

### DIFF
--- a/app/mailers/pay/user_mailer.rb
+++ b/app/mailers/pay/user_mailer.rb
@@ -5,8 +5,8 @@ module Pay
 
       attachments[charge.filename] = charge.receipt.render
       mail(
-        to: "#{user.name} <#{user.email}>",
-        subject: "Payment receipt"
+        to: to(user),
+        subject: "Payment receipt",
       )
     end
 
@@ -14,16 +14,26 @@ module Pay
       @user, @charge = user, charge
 
       mail(
-        to: "#{user.name} <#{user.email}>",
+        to: to(user),
         subject: "Payment refunded",
       )
     end
 
     def subscription_renewing(user, subscription)
       mail(
-        to: "#{user.name} <#{user.email}>",
+        to: to(user),
         subject: "Your upcoming subscription renewal",
       )
+    end
+
+    private
+
+    def to(user)
+      if user.respond_to?(:name)
+        "#{user.name} <#{user.email}>"
+      else
+        user.email
+      end
     end
   end
 end

--- a/app/mailers/pay/user_mailer.rb
+++ b/app/mailers/pay/user_mailer.rb
@@ -6,7 +6,7 @@ module Pay
       attachments[charge.filename] = charge.receipt.render
       mail(
         to: "#{user.name} <#{user.email}>",
-        from: "Payment receipt"
+        subject: "Payment receipt"
       )
     end
 
@@ -15,7 +15,7 @@ module Pay
 
       mail(
         to: "#{user.name} <#{user.email}>",
-        from: "Payment refunded",
+        subject: "Payment refunded",
       )
     end
 

--- a/app/mailers/pay/user_mailer.rb
+++ b/app/mailers/pay/user_mailer.rb
@@ -6,7 +6,7 @@ module Pay
       attachments[charge.filename] = charge.receipt.render
       mail(
         to: to(user),
-        subject: "Payment receipt",
+        subject: Pay.email_receipt_subject,
       )
     end
 
@@ -15,14 +15,14 @@ module Pay
 
       mail(
         to: to(user),
-        subject: "Payment refunded",
+        subject: Pay.email_refund_subject,
       )
     end
 
     def subscription_renewing(user, subscription)
       mail(
         to: to(user),
-        subject: "Your upcoming subscription renewal",
+        subject: Pay.email_renewing_subject,
       )
     end
 

--- a/app/views/pay/user_mailer/receipt.html.erb
+++ b/app/views/pay/user_mailer/receipt.html.erb
@@ -10,8 +10,8 @@ Amount: USD <%= ActionController::Base.helpers.number_to_currency(@charge.amount
 Charged to: <%= @charge.card_type %> (**** **** **** <%= @charge.card_last4 %>)<br/>
 Transaction ID: <%= @charge.id %><br/>
 Date: <%= @charge.created_at %><br/>
-<% if @charge.user.extra_billing_info? %>
-<%= @charge.user.extra_billing_info %><br/>
+<% if @charge.owner.extra_billing_info? %>
+<%= @charge.owner.extra_billing_info %><br/>
 <% end %>
 <br/>
 <br/>

--- a/app/views/pay/user_mailer/receipt.html.erb
+++ b/app/views/pay/user_mailer/receipt.html.erb
@@ -7,7 +7,7 @@ RECEIPT - SUBSCRIPTION<br/>
 <br/>
 Amount: USD <%= ActionController::Base.helpers.number_to_currency(@charge.amount / 100.0) %><br/>
 <br/>
-Charged to: <%= @charge.card_brand %> (**** **** **** <%= @charge.card_last4 %>)<br/>
+Charged to: <%= @charge.card_type %> (**** **** **** <%= @charge.card_last4 %>)<br/>
 Transaction ID: <%= @charge.id %><br/>
 Date: <%= @charge.created_at %><br/>
 <% if @charge.user.extra_billing_info? %>

--- a/app/views/pay/user_mailer/refund.html.erb
+++ b/app/views/pay/user_mailer/refund.html.erb
@@ -1,0 +1,21 @@
+We have processed your refund.<br/>
+Please allow up to 7 business days for your refund to appear in your account<br/>
+<br/>
+Questions? Please reply to this email.<br/>
+<br/>
+------------------------------------<br/>
+RECEIPT - REFUND<br/>
+<br/>
+Amount: USD <%= ActionController::Base.helpers.number_to_currency(@charge.amount / 100.0) %><br/>
+<br/>
+Refunded to: <%= @charge.card_type %> (**** **** **** <%= @charge.card_last4 %>)<br/>
+Transaction ID: <%= @charge.id %><br/>
+Date: <%= @charge.created_at %><br/>
+<% if @charge.owner.extra_billing_info? %>
+<%= @charge.owner.extra_billing_info %><br/>
+<% end %>
+<br/>
+<br/>
+<%= Pay.business_name %><br/>
+<%= simple_format Pay.business_address %>
+------------------------------------<br/>

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -33,6 +33,13 @@ module Pay
   mattr_accessor :send_emails
   @@send_emails = true
 
+  mattr_accessor :email_receipt_subject
+  @@email_receipt_subject = 'Payment receipt'
+  mattr_accessor :email_refund_subject
+  @@email_refund_subject = 'Payment refunded'
+  mattr_accessor :email_renewing_subject
+  @@email_renewing_subject = 'Your upcoming subscription renewal'
+
   def self.setup
     yield self
   end

--- a/test/mailers/pay/user_mailer_test.rb
+++ b/test/mailers/pay/user_mailer_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+ 
+class UserMailerTest < ActionMailer::TestCase
+  test "receipt" do
+    user = User.new(email: 'john@example.org')
+    user.stubs(:extra_billing_info?).returns(true)
+    user.stubs(:extra_billing_info).returns('extra billing info')
+    charge = Charge.new(amount: 100, owner: user)
+    receipt = mock('receipt')
+    receipt.stubs(:render).returns('render content')
+    charge.stubs(:filename).returns('file.name')
+    charge.stubs(:receipt).returns(receipt)
+    email = Pay::UserMailer.receipt(user, charge)
+ 
+    assert_equal ['john@example.org'], email.to
+    assert_equal 'Payment receipt', email.subject
+
+    # Configurable subject
+    new_subject = 'My email receipt subject'
+    Pay.email_receipt_subject = new_subject
+    email = Pay::UserMailer.receipt(user, charge)
+    assert_equal new_subject, email.subject
+  end
+
+  test "refund" do
+    user = User.new(email: 'john@example.org')
+    user.stubs(:extra_billing_info?).returns(true)
+    user.stubs(:extra_billing_info).returns('extra billing info')
+    charge = Charge.new(amount: 100, owner: user)
+    receipt = mock('receipt')
+    receipt.stubs(:render).returns('render content')
+    charge.stubs(:filename).returns('file.name')
+    charge.stubs(:receipt).returns(receipt)
+    email = Pay::UserMailer.refund(user, charge)
+ 
+    assert_equal ['john@example.org'], email.to
+    assert_equal 'Payment refunded', email.subject
+
+    # Configurable subject
+    new_subject = 'My email refund subject'
+    Pay.email_refund_subject = new_subject
+    email = Pay::UserMailer.refund(user, charge)
+    assert_equal new_subject, email.subject
+  end
+
+  test "renewal" do
+    user = User.new(email: 'john@example.org')
+    user.stubs(:extra_billing_info?).returns(true)
+    user.stubs(:extra_billing_info).returns('extra billing info')
+    charge = Charge.new(amount: 100, owner: user)
+    receipt = mock('receipt')
+    receipt.stubs(:render).returns('render content')
+    charge.stubs(:filename).returns('file.name')
+    charge.stubs(:receipt).returns(receipt)
+    email = Pay::UserMailer.subscription_renewing(user, charge)
+ 
+    assert_equal ['john@example.org'], email.to
+    assert_equal 'Your upcoming subscription renewal', email.subject
+
+    # Configurable subject
+    new_subject = 'My email renewal subject'
+    Pay.email_renewing_subject = new_subject
+    email = Pay::UserMailer.subscription_renewing(user, charge)
+    assert_equal new_subject, email.subject
+  end
+end


### PR DESCRIPTION
I discovered some more issues with the mailers, the subject field appeared to be named `From` - and it appears that the column name on charge is `card_type` and on users it's `card_brand` - we probably want to be consistent here?