### PR TITLE
Remove receipt_attributes check for now

### DIFF
--- a/app/models/concerns/pay/chargeable.rb
+++ b/app/models/concerns/pay/chargeable.rb
@@ -36,7 +36,7 @@ module Pay
       update(amount_refunded: amount)
     end
 
-    if defined?(Receipts::Receipt) && required_receipt_attributes?
+    if defined?(Receipts::Receipt)
       def receipt
         Receipts::Receipt.new(
           id: id,
@@ -65,15 +65,6 @@ module Pay
 
     def charged_to
       "#{card_type} (**** **** **** #{card_last4})"
-    end
-
-    private
-
-    def required_receipt_attributes?
-      Pay.config.application_name.present? &&
-      Pay.config.business_name &&
-      Pay.config.business_address &&
-      Pay.config.support_email
     end
   end
 end

--- a/test/pay/chargeable_test.rb
+++ b/test/pay/chargeable_test.rb
@@ -14,20 +14,4 @@ class Pay::Chargeable::Test < ActiveSupport::TestCase
     @chargeable.card_last4 = 1234
     assert_equal "VISA (**** **** **** 1234)", @chargeable.charged_to
   end
-
-  test '#receipt is only available if Receipts::Receipt is defined' do
-    refute @chargeable.respond_to?(:receipt)
-
-    module Receipts
-      def receipt; end
-    end
-
-    class MyCharge < Charge
-      include Pay::Chargeable
-      include Receipts
-    end
-
-    mychargeable = MyCharge.new
-    assert mychargeable.respond_to?(:receipt)
-  end
 end

--- a/test/pay/chargeable_test.rb
+++ b/test/pay/chargeable_test.rb
@@ -14,4 +14,20 @@ class Pay::Chargeable::Test < ActiveSupport::TestCase
     @chargeable.card_last4 = 1234
     assert_equal "VISA (**** **** **** 1234)", @chargeable.charged_to
   end
+
+  test '#receipt is only available if Receipts::Receipt is defined' do
+    refute @chargeable.respond_to?(:receipt)
+
+    module Receipts
+      def receipt; end
+    end
+
+    class MyCharge < Charge
+      include Pay::Chargeable
+      include Receipts
+    end
+
+    mychargeable = MyCharge.new
+    assert mychargeable.respond_to?(:receipt)
+  end
 end


### PR DESCRIPTION
I introduced a pretty nasty bug when I tried to check for `Pay.config` attributes. I don't think I know ruby well enough to fix it - so let's just stop being this defensive for now and remove those checks.

cc: @excid3 