### PR TITLE
Added a few tests for the StripeEvent handlers

### DIFF
--- a/lib/pay/stripe/charge_succeeded.rb
+++ b/lib/pay/stripe/charge_succeeded.rb
@@ -21,7 +21,7 @@ module Pay
           processor_id:   object.id,
         )
 
-        charge.update(
+        charge.update!(
           amount:         object.amount,
           card_last4:     object.source.last4,
           card_type:      object.source.brand,

--- a/lib/pay/stripe/charge_succeeded.rb
+++ b/lib/pay/stripe/charge_succeeded.rb
@@ -34,7 +34,7 @@ module Pay
       end
 
       def notify_user(user, charge)
-        if Pay.send_emails && charge.receipt
+        if Pay.send_emails && charge.respond_to?(:receipt)
           Pay::UserMailer.receipt(user, charge).deliver_later
         end
       end

--- a/test/pay/stripe/charge_refunded_test.rb
+++ b/test/pay/stripe/charge_refunded_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class Pay::Stripe::ChargeRefundedTest < ActiveSupport::TestCase
+  setup do
+    @event = OpenStruct.new
+    @event.data = JSON.parse(File.read('test/support/fixtures/charge_refunded_event.json'), object_class: OpenStruct)
+  end
+
+  test "a charge is updated with refunded amount" do
+    @user = User.create!(email: 'gob@bluth.com', processor: :stripe, processor_id: @event.data.object.customer)
+    charge = @user.charges.create!(processor: :stripe, processor_id: @event.data.object.id, amount: 500, card_type: 'Visa', card_last4: '4444', card_exp_month: 1, card_exp_year: 2019)
+
+    Pay::Stripe::ChargeRefunded.new.call(@event)
+
+    assert_equal 500, charge.reload.amount_refunded
+  end
+
+  test "a charge isn't updated with the refunded amount if a corresponding charge can't be found (obviously)" do
+    @user = User.create!(email: 'gob@bluth.com', processor: :stripe, processor_id: 'does-not-exist')
+    charge = @user.charges.create!(processor: :stripe, processor_id: 'doesntexist', amount: 500, card_type: 'Visa', card_last4: '4444', card_exp_month: 1, card_exp_year: 2019)
+
+    assert_nil charge.reload.amount_refunded
+  end
+end

--- a/test/pay/stripe/charge_succeeded_test.rb
+++ b/test/pay/stripe/charge_succeeded_test.rb
@@ -1,0 +1,42 @@
+require 'test_helper'
+
+class Pay::Stripe::ChargeSucceededTest < ActiveSupport::TestCase
+  setup do
+    @event = OpenStruct.new
+    @event.data = JSON.parse(File.read('test/support/fixtures/charge_succeeded_event.json'), object_class: OpenStruct)
+  end
+
+  test "a charge is created" do
+    @user = User.create!(email: 'gob@bluth.com', processor: :stripe, processor_id: @event.data.object.customer)
+
+    assert_difference "Charge.count" do
+      Pay::Stripe::ChargeSucceeded.new.call(@event)
+    end
+
+    charge = Charge.last
+    assert_equal 500, charge.amount
+    assert_equal '4444', charge.card_last4
+    assert_equal 'Visa', charge.card_type
+    assert_equal '1', charge.card_exp_month
+    assert_equal '2019', charge.card_exp_year
+
+  end
+
+  test "a charge isn't created if no corresponding user can be found" do
+    @user = User.create!(email: 'gob@bluth.com', processor: :stripe, processor_id: 'does-not-exist')
+
+    assert_no_difference "Charge.count" do
+      Pay::Stripe::ChargeSucceeded.new.call(@event)
+    end
+  end
+
+  test "a charge isn't created if it already exists" do
+    @user = User.create!(email: 'gob@bluth.com', processor: :stripe, processor_id: @event.data.object.customer)
+
+    @user.charges.create!(amount: 100, processor: :stripe, processor_id: 'ch_chargeid', card_type: 'Visa', card_exp_month: 1, card_exp_year: 2019, card_last4: '4444')
+
+    assert_no_difference "Charge.count" do
+      Pay::Stripe::ChargeSucceeded.new.call(@event)
+    end
+  end
+end

--- a/test/support/fixtures/charge_refunded_event.json
+++ b/test/support/fixtures/charge_refunded_event.json
@@ -1,0 +1,8 @@
+{
+  "object": {
+    "id": "ch_chargeid",
+    "amount_refunded": 500,
+    "created": 1546324243,
+    "customer": "cus_customerid"
+  }
+}

--- a/test/support/fixtures/charge_succeeded_event.json
+++ b/test/support/fixtures/charge_succeeded_event.json
@@ -1,0 +1,14 @@
+{
+  "object": {
+    "id": "ch_chargeid",
+    "amount": 500,
+    "created": 1546332337,
+    "customer": "cus_customerid",
+    "source": {
+      "brand": "Visa",
+      "exp_month": 1,
+      "exp_year": 2019,
+      "last4": "4444"
+    }
+  }
+}


### PR DESCRIPTION
The beginnings of some StripeEvent tests. I think we should use `update!` instead of `update` in `ChargeSucceeded` - we could end up in a situation where we won't create the charge, and have no idea that we haven't done so if we don't raise an exception if `update` fails (due to validation error or whatever)

cc: @excid3 