### PR TITLE
configure travis to test with ruby 2.4.1, 2.5.3 and 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: ruby
+rvm:
+  - 2.4.1
+  - 2.5.3
+  - 2.6.0
 script:
   - bundle exec rake db:test:prepare
   - bundle exec rake test


### PR DESCRIPTION
What do you think of testing against ruby 2.4.1, 2.5.3 and 2.6.0?