### PR TITLE
Added `dependent: destroy` to Billable :charges :subscriptions

### DIFF
--- a/lib/pay/billable.rb
+++ b/lib/pay/billable.rb
@@ -7,8 +7,8 @@ module Pay
     included do
       include Pay::Billable::SyncEmail
 
-      has_many :charges, class_name: Pay.chargeable_class, foreign_key: :owner_id, inverse_of: :owner
-      has_many :subscriptions, class_name: Pay.subscription_class, foreign_key: :owner_id, inverse_of: :owner
+      has_many :charges, class_name: Pay.chargeable_class, foreign_key: :owner_id, inverse_of: :owner, dependent: :destroy
+      has_many :subscriptions, class_name: Pay.subscription_class, foreign_key: :owner_id, inverse_of: :owner, dependent: :destroy
 
       attribute :plan, :string
       attribute :quantity, :integer


### PR DESCRIPTION
So all charges + subscriptions will be removed if Billable/User gets destroyed.

Not 100% certain—thus draft PR—if this has any side-effects, but otherwise this is behaviour one wants.