### PR TITLE
Provide method that checks for active trial or subscription

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,21 @@ user = User.find_by(email: 'gob@bluthcompany.co')
 user.subscription(name: 'bananastand+')
 ```
 
+#### Checking a User's Trial/Subscription Status
+
+```ruby
+user = User.find_by(email: 'george.senior@bluthcompany.co')
+user.on_trial_or_subscribed?
+```
+
+The `on_trial_or_subscribed?` method has two optional arguments with default values.
+
+```ruby
+def on_trial_or_subscribed?(name: 'default', plan: nil)
+  ...
+end
+```
+
 #### Checking a User's Subscription Status
 
 ```ruby

--- a/lib/pay/billable.rb
+++ b/lib/pay/billable.rb
@@ -76,6 +76,11 @@ module Pay
       subscription.active? && subscription.processor_plan == processor_plan
     end
 
+    def on_trial_or_subscribed?(name: 'default', processor_plan: nil)
+      on_trial?(name: name, plan: processor_plan) ||
+        subscribed?(name: name, processor_plan: processor_plan)
+    end
+
     def subscription(name: 'default')
       subscriptions.for_name(name).last
     end


### PR DESCRIPTION
Added a convenience method to billable that checks for either an active trial, or a subscription